### PR TITLE
%files should not own mandir directly

### DIFF
--- a/tecla.spec
+++ b/tecla.spec
@@ -71,7 +71,7 @@ rm $RPM_BUILD_ROOT%{_mandir}/man1/enhance.1
 %defattr(-,root,root,-)
 %doc CHANGES README RELEASE.NOTES
 %license LICENSE.TERMS
-%{_mandir}
+%{_mandir}/*/*
 %{_libdir}/libtecla.so.*
 %{_libdir}/libtecla_r.so.*
 


### PR DESCRIPTION
Ran into an issue after successfully creating the RPM. Installing has a conflict with /usr/share/man with "filesystem". The specfile should not have libtecla own the mandir directly, but the man pages that belong to the package.
